### PR TITLE
Fix Python <3.12 SyntaxError in SQLBaseTable's NONE-operator clause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,3 +81,17 @@ Fixes `ContainerTable`, which was added without a way to resolve its runtime URL
 * Added `tests/test_container_table.py`: covers URL resolution (default and per-`SDTP_DEPLOYMENT`), the legacy `name`/`computation` alias fields, and end-to-end `connect_with_server()` behavior against a local `httpserver` standing in for the container.
 * Full test suite passing (219 tests).
 * Edge case coverage for strings like `'NaN'`, `'null'`, and `'None'` validated
+
+# SDTP 2026.8.11 Release Notes
+
+## 🔧 Patch Release Summary
+
+Fixes a Python 3.11 (and earlier) compatibility break introduced in 2026.8.10: `sql_base_table.py` used an f-string with the same quote character nested inside itself, which only parses under PEP 701's relaxed grammar (Python 3.12+). This silently violated the package's own stated `requires-python = ">=3.8"` — `import sdtp` raised a `SyntaxError` on 3.8–3.11.
+
+## ✅ Fixed
+
+* `SQLBaseTable`'s `NONE`-operator filter clause (`f"NOT ({" OR ".join(sub_clauses)})"`) now uses a differently-quoted inner string, valid on all supported Python versions.
+
+## 🧪 Testing
+
+* Verified `import sdtp` succeeds on a real Python 3.11 interpreter (previously failed with `SyntaxError: f-string: expecting '}'`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sdtp"
-version = "2026.8.10"
+version = "2026.8.11"
 description = "Simple Data Transfer Protocol (SDTP) reference implementation"
 authors = [
     { name = "The Regents of the University of California", email = "opensource@ucop.edu" }

--- a/src/sdtp.egg-info/PKG-INFO
+++ b/src/sdtp.egg-info/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 2.4
 Name: sdtp
-Version: 2026.1.18
+Version: 2026.8.11
 Summary: Simple Data Transfer Protocol (SDTP) reference implementation
 Author-email: The Regents of the University of California <opensource@ucop.edu>
 License-Expression: BSD-3-Clause

--- a/src/sdtp/sql_base_table.py
+++ b/src/sdtp/sql_base_table.py
@@ -263,7 +263,7 @@ class BaseSQLTable(SDMLTable):
             elif operator == "ANY":
                 return " OR ".join(sub_clauses), params
             elif operator == "NONE":
-                return f"NOT ({" OR ".join(sub_clauses)})", params
+                return f"NOT ({' OR '.join(sub_clauses)})", params
 
         # 2. Extract Atomic Column Constraints
         column = spec.get("column")


### PR DESCRIPTION
## Summary
- `sql_base_table.py`'s NONE-operator filter clause used an f-string with the same quote character (`"`) nested inside itself — only parses under PEP 701's relaxed grammar (Python 3.12+), silently violating the package's own `requires-python = ">=3.8"`. `import sdtp` raised a `SyntaxError` on 3.8–3.11. Introduced in 2026.8.10.
- Bumps version to 2026.8.11 (2026.8.10 is already live on PyPI and can't be re-published).
- Adds a CHANGELOG entry.

## Verification
- Confirmed against a real Python 3.11 interpreter (not just this dev machine's newer Python): before the fix, `import sdtp` failed at collection time; after the fix, it imports cleanly and the full test suite passes (219 tests).
- Also checked all other `sdtp==2026.8.10` was the only affected version — 2026.1.18, 2025.10.25, 2025.10.2, and 2025.9.17 all import fine on 3.11.

## Note (not fixed here, flagging for visibility)
There's no CI test workflow in this repo — only publish/deploy/version-bump jobs, all using generic `python-version: '3.x'` (almost certainly resolves to 3.12+ on `ubuntu-latest`). That's the real reason this shipped: nothing in CI runs the test suite against the Python versions `requires-python` claims to support.

## Test plan
- [x] `import sdtp` on Python 3.11 (was failing, now passes)
- [x] Full test suite (219 tests) on Python 3.11